### PR TITLE
refactor(member): 활동 2차 QA 피드백 반영 수정 

### DIFF
--- a/.changeset/happy-clocks-shave.md
+++ b/.changeset/happy-clocks-shave.md
@@ -1,0 +1,5 @@
+---
+"@clab-platforms/member": patch
+---
+
+refactor(member): 활동 2차 QA 피드백 반영 수정 

--- a/apps/member/src/api/activity.ts
+++ b/apps/member/src/api/activity.ts
@@ -274,7 +274,7 @@ export async function postActivityBoard({
     activityGroupId: activityGroupId,
   };
 
-  let fileUrl: string | null = null;
+  let fileUrl: Array<string> | null = null;
 
   if (
     body.category === ACTIVITY_BOARD_CATEGORY_STATE.ASSIGNMENT &&
@@ -289,7 +289,7 @@ export async function postActivityBoard({
       files,
     });
 
-    fileUrl = data[0].fileUrl;
+    fileUrl = data.map((file) => file.fileUrl);
   } else if (
     body.category === ACTIVITY_BOARD_CATEGORY_STATE.WEEKLY_ACTIVITY &&
     memberId &&
@@ -301,7 +301,7 @@ export async function postActivityBoard({
       files,
     });
 
-    fileUrl = data[0].fileUrl;
+    fileUrl = data.map((file) => file.fileUrl);
   }
 
   const { data } = await server.post<
@@ -311,7 +311,7 @@ export async function postActivityBoard({
     url: createPagination(END_POINT.ACTIVITY_GROUP_BOARD, params),
     body: {
       ...body,
-      fileUrls: fileUrl ? [fileUrl] : undefined,
+      fileUrls: fileUrl ? fileUrl : undefined,
     },
   });
 
@@ -328,7 +328,7 @@ export async function patchActivityBoard({
   body,
   files,
 }: PatchActivityBoardParams) {
-  let fileUrl: string | null = null;
+  let fileUrl: Array<string> | null = null;
 
   if (groupBoardId === null && groupId && files) {
     // 파일이 있을 경우 파일 업로드 진행 (주차별 활동 파일)
@@ -336,8 +336,7 @@ export async function patchActivityBoard({
       groupId: groupId,
       files,
     });
-
-    fileUrl = data[0].fileUrl;
+    fileUrl = data.map((file) => file.fileUrl);
   } else if (groupId && groupBoardId && files) {
     // 파일이 있을 경우 파일 업로드 진행 (과제 파일)
     const data = await postUploadedFileAssignment({
@@ -345,8 +344,7 @@ export async function patchActivityBoard({
       groupBoardId: groupBoardId,
       files,
     });
-
-    fileUrl = data[0].fileUrl;
+    fileUrl = data.map((file) => file.fileUrl);
   }
 
   const { data } = await server.patch<
@@ -358,7 +356,7 @@ export async function patchActivityBoard({
     }),
     body: {
       ...body,
-      fileUrls: fileUrl ? [fileUrl] : undefined,
+      fileUrls: fileUrl ? fileUrl : undefined,
     },
   });
 

--- a/apps/member/src/components/common/File/File.tsx
+++ b/apps/member/src/components/common/File/File.tsx
@@ -1,24 +1,47 @@
 import { createURL } from '@clab-platforms/utils';
 
 import { SERVER_BASE_URL } from '@constants/api';
+import useToast from '@hooks/common/useToast';
 
 interface FileProps extends React.PropsWithChildren {
   href: string;
+  name: string;
 }
 
-const File = ({ children, href }: FileProps) => {
+const File = ({ href, name }: FileProps) => {
+  const toast = useToast();
+
   if (!href.startsWith(SERVER_BASE_URL)) {
     href = createURL(SERVER_BASE_URL, href);
   }
+
+  const handleClickImgLink = () => {
+    fetch(href)
+      .then((res) => res.blob())
+      .then((blob) => {
+        const href = window.URL.createObjectURL(new Blob([blob]));
+        const a = document.createElement('a');
+        a.href = href;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        window.URL.revokeObjectURL(href);
+        a.remove();
+      })
+      .catch(() => {
+        toast({ state: 'error', message: '파일 다운로드에 실패했습니다' });
+      });
+  };
 
   return (
     <a
       href={href}
       target="_blank"
-      className="underline-offset-4 hover:underline"
+      className="text-gray-700 underline-offset-4 hover:underline"
       rel="noreferrer"
+      onClick={handleClickImgLink}
     >
-      {children}
+      {name}
     </a>
   );
 };

--- a/apps/member/src/components/common/Notice/Notice.tsx
+++ b/apps/member/src/components/common/Notice/Notice.tsx
@@ -42,7 +42,7 @@ const Notice = ({
           },
         )}
       >
-        D-{dDay}
+        {dDay === 0 ? 'D-Day' : `D-${dDay}`}
       </div>
     );
   }

--- a/apps/member/src/components/group/ActivityAssignmentEditor/ActivityAssignmentEditor.tsx
+++ b/apps/member/src/components/group/ActivityAssignmentEditor/ActivityAssignmentEditor.tsx
@@ -40,15 +40,17 @@ const ActivityAssignmentEditor = ({ parentId, activityGroupId }: Props) => {
   };
   const handleAddAssignmentClick = () => {
     const formData = new FormData();
-    const file = uploaderRef.current?.files?.[0];
+    const files = uploaderRef.current?.files;
 
     if (!board.title || !board.content || !board.dueDateTime)
       return toast({
         state: 'error',
         message: '제목, 내용, 종료 일시는 필수 입력 요소입니다.',
       });
-    if (file) {
-      formData.append(FORM_DATA_KEY, file);
+    if (files) {
+      Array.from(files).forEach((file) => {
+        formData.append(FORM_DATA_KEY, file);
+      });
     }
 
     activityGroupBoardMutate(
@@ -60,7 +62,7 @@ const ActivityAssignmentEditor = ({ parentId, activityGroupId }: Props) => {
           category: ACTIVITY_BOARD_CATEGORY_STATE.ASSIGNMENT,
           ...board,
         },
-        files: file ? formData : undefined,
+        files: files?.length ? formData : undefined,
       },
       { onSuccess: () => setBoard(defaultBoard) },
     );
@@ -68,17 +70,7 @@ const ActivityAssignmentEditor = ({ parentId, activityGroupId }: Props) => {
 
   return (
     <Section>
-      <Section.Header title="과제 관리">
-        <div className="space-x-2">
-          <Button
-            size="sm"
-            onClick={handleAddAssignmentClick}
-            disabled={activityGroupBoardIsPending}
-          >
-            추가
-          </Button>
-        </div>
-      </Section.Header>
+      <Section.Header title="과제 관리" />
       <Section.Body className="space-y-4">
         <div className="space-y-2">
           <Input
@@ -112,10 +104,17 @@ const ActivityAssignmentEditor = ({ parentId, activityGroupId }: Props) => {
               <label htmlFor="fileUpload" className="mb-1 ml-1 text-xs">
                 첨부 파일
               </label>
-              <input ref={uploaderRef} id="fileUpload" type="file" />
+              <input ref={uploaderRef} id="fileUpload" type="file" multiple />
             </div>
           </Grid>
         </div>
+        <Button
+          className="w-full"
+          onClick={handleAddAssignmentClick}
+          disabled={activityGroupBoardIsPending}
+        >
+          추가
+        </Button>
       </Section.Body>
     </Section>
   );

--- a/apps/member/src/components/group/ActivityDetailSection/ActivityDetailSection.tsx
+++ b/apps/member/src/components/group/ActivityDetailSection/ActivityDetailSection.tsx
@@ -20,14 +20,14 @@ const ActivityDetailSection = ({ data }: ActivityDetailSectionProps) => {
     <div className="space-y-4">
       <Image
         width="w-full"
-        height="h-[300px]"
+        height="h-[320px]"
         src={data.imageUrl}
         alt={data.name}
         className="rounded-lg border object-cover"
       />
-      <Section>
+      <Section className="flex h-[160px] flex-col justify-between overflow-scroll">
         <h1 className="text-xl font-bold">{data.name}</h1>
-        <p className="my-1 text-sm">{data.content}</p>
+        <p className="my-1 whitespace-pre-line text-sm ">{data.content}</p>
         <div className="flex items-center gap-1 text-sm text-gray-500">
           <CertificateSolidOutline />
           <span>{data.category}</span>

--- a/apps/member/src/components/group/ActivityNoticeEditor/ActivityNoticeEditor.tsx
+++ b/apps/member/src/components/group/ActivityNoticeEditor/ActivityNoticeEditor.tsx
@@ -59,17 +59,7 @@ const ActivityNoticeEditor = ({ groupId, data }: ActivityNoticeEditorProps) => {
   return (
     <>
       <Section>
-        <Section.Header title="공지 관리">
-          <div className="space-x-2">
-            <Button
-              size="sm"
-              onClick={handleAddNoticeButtonClick}
-              disabled={activityGroupBoardIsPending}
-            >
-              추가
-            </Button>
-          </div>
-        </Section.Header>
+        <Section.Header title="공지 관리" />
         <Section.Body className="space-y-4">
           <div className="space-y-2">
             <Input
@@ -92,6 +82,13 @@ const ActivityNoticeEditor = ({ groupId, data }: ActivityNoticeEditorProps) => {
           </div>
           <Hr>미리보기</Hr>
           <ActivityNoticeSection data={[notice, ...data]} />
+          <Button
+            className="w-full"
+            onClick={handleAddNoticeButtonClick}
+            disabled={activityGroupBoardIsPending}
+          >
+            추가
+          </Button>
         </Section.Body>
       </Section>
       <ActivityConfigTableSection tableList={data} groupId={groupId} />

--- a/apps/member/src/components/group/ActivityNoticeSection/ActivityNoticeSection.tsx
+++ b/apps/member/src/components/group/ActivityNoticeSection/ActivityNoticeSection.tsx
@@ -18,7 +18,7 @@ interface ActivityNoticeSectionProps {
 
 interface ActivityNoticeSectionItemProps {
   className?: string;
-  onClick: (content: string) => void;
+  onClick: (content: string, title?: string) => void;
   data: ActivityBoardType;
 }
 
@@ -37,9 +37,9 @@ const ActivityNoticeSection = ({ data }: ActivityNoticeSectionProps) => {
   const latestNotice = sortedNotices[0];
   const otherNotices = sortedNotices.slice(1);
 
-  const onClickAlert = (content: string) => {
+  const onClickAlert = (content: string, title?: string) => {
     openModal({
-      title: '📣 공지사항',
+      title: `📣 ${title}`,
       content: content,
     });
   };
@@ -94,11 +94,13 @@ ActivityNoticeSection.Item = ({
     >
       <div
         className="flex cursor-pointer items-center justify-between gap-2"
-        onClick={() => onClick(data.content)}
+        onClick={() => onClick(data.content, data.title)}
       >
         <p className="w-full truncate">{data.title}</p>
         <p className="whitespace-nowrap text-sm text-gray-500">
-          {formattedDate(toKoreaISOString(data.updatedAt))}
+          {formattedDate(
+            data.updatedAt ? toKoreaISOString(data.updatedAt) : String(dayjs()),
+          )}
         </p>
       </div>
     </div>

--- a/apps/member/src/components/group/ActivityPostEditor/ActivityPostEditor.tsx
+++ b/apps/member/src/components/group/ActivityPostEditor/ActivityPostEditor.tsx
@@ -66,7 +66,7 @@ const ActivityPostEditor = ({
   };
   const handleAddWeeklyClick = () => {
     const formData = new FormData();
-    const file = uploaderRef.current?.files?.[0];
+    const files = uploaderRef.current?.files;
 
     if (!post.title || !post.content) {
       return toast({
@@ -74,8 +74,10 @@ const ActivityPostEditor = ({
         message: '제목, 내용은 필수 입력 요소입니다.',
       });
     }
-    if (file) {
-      formData.append(FORM_DATA_KEY, file);
+    if (files?.length) {
+      Array.from(files).forEach((file) => {
+        formData.append(FORM_DATA_KEY, file);
+      });
     }
 
     const activityBoardItem: SubmitBoardType = {
@@ -87,7 +89,7 @@ const ActivityPostEditor = ({
         activityGroupId: groupId,
         memberId: myProfile.id,
         body: activityBoardItem,
-        files: file ? formData : undefined,
+        files: files?.length ? formData : undefined,
       },
       { onSuccess: () => setPost(defaultPost) },
     );
@@ -109,15 +111,7 @@ const ActivityPostEditor = ({
   return (
     <>
       <Section>
-        <Section.Header title="주차별 활동 관리">
-          <Button
-            size="sm"
-            onClick={handleAddWeeklyClick}
-            disabled={activityGroupBoardIsPending}
-          >
-            추가
-          </Button>
-        </Section.Header>
+        <Section.Header title="주차별 활동 관리" />
         <Section.Body className="space-y-4">
           <div className="space-y-2">
             <Input
@@ -142,7 +136,7 @@ const ActivityPostEditor = ({
               <label htmlFor="fileUpload" className="mb-1 ml-1 text-xs">
                 첨부 파일
               </label>
-              <input ref={uploaderRef} id="fileUpload" type="file" />
+              <input ref={uploaderRef} id="fileUpload" type="file" multiple />
             </div>
           </div>
           <Hr>미리보기</Hr>
@@ -155,6 +149,13 @@ const ActivityPostEditor = ({
               isParticipant
             />
           </Section>
+          <Button
+            className="w-full"
+            onClick={handleAddWeeklyClick}
+            disabled={activityGroupBoardIsPending}
+          >
+            추가
+          </Button>
         </Section.Body>
       </Section>
       {activities.map((weeklyData, index) => (
@@ -166,7 +167,7 @@ const ActivityPostEditor = ({
                 color="orange"
                 onClick={() => handleAssignmentEditClick(index)}
               >
-                과제 관리
+                {editAssignment[index] ? '과제 닫기' : '과제 열기'}
               </Button>
               <Button
                 size="sm"

--- a/apps/member/src/components/group/AssignmentFeedbackModal/AssignmentFeedbackModal.tsx
+++ b/apps/member/src/components/group/AssignmentFeedbackModal/AssignmentFeedbackModal.tsx
@@ -83,7 +83,7 @@ const AssignmentFeedbackModal = ({
             ? post.files.map((file) => (
                 <div key={file.fileUrl} className="flex gap-2">
                   <p>제출 파일 | </p>
-                  <File href={file.fileUrl}>{file.originalFileName}</File>
+                  <File href={file.fileUrl} name={file.originalFileName} />
                 </div>
               ))
             : '-'}

--- a/apps/member/src/components/group/AssignmentListSection/AssignmentListSection.tsx
+++ b/apps/member/src/components/group/AssignmentListSection/AssignmentListSection.tsx
@@ -80,9 +80,11 @@ const AssignmentListSection = () => {
                   <Table.Cell className="hover:underline">
                     {item.files
                       ? item.files.map((file) => (
-                          <File key={file.fileUrl} href={file.fileUrl}>
-                            {file.originalFileName}
-                          </File>
+                          <File
+                            href={file.fileUrl}
+                            name={file.originalFileName}
+                            key={file.fileUrl}
+                          />
                         ))
                       : '-'}
                   </Table.Cell>

--- a/apps/member/src/components/group/GroupCard/GroupCard.tsx
+++ b/apps/member/src/components/group/GroupCard/GroupCard.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
-import { Grid } from '@clab-platforms/design-system';
+import { Badge, Grid } from '@clab-platforms/design-system';
 import {
   CertificateSolidOutline,
   DateRangeOutline,
@@ -10,11 +10,14 @@ import { cn } from '@clab-platforms/utils';
 import Image from '@components/common/Image/Image';
 
 import { PATH_FINDER } from '@constants/path';
+import { createImageUrl } from '@utils/api';
 import { getDateSemester } from '@utils/date';
 
 import type { ActivityGroupItem } from '@type/activity';
 
-interface GroupCardProps extends ActivityGroupItem {}
+interface GroupCardProps extends ActivityGroupItem {
+  applied?: boolean;
+}
 
 interface InfoCardProps {
   title: string;
@@ -67,27 +70,31 @@ const GroupCard = ({
   participantCount,
   weeklyActivityCount,
   createdAt,
+  applied,
 }: GroupCardProps) => {
   const navigate = useNavigate();
-  const leaderName = leaders[0].name;
-  const leaderId = leaders[0].id;
+  const leaderName = leaders ? leaders[0].name : '';
+  const leaderId = leaders ? leaders[0].id : '';
 
   return (
     <Grid
       col="3"
       gap="sm"
-      className="h-[227px] cursor-pointer overflow-auto rounded-lg border transition-colors hover:bg-gray-50"
+      className="h-[227px] cursor-pointer overflow-hidden rounded-lg border transition-colors hover:bg-gray-50"
       onClick={() => navigate(PATH_FINDER.ACTIVITY_DETAIL(id))}
     >
       <Image
-        src={imageUrl}
+        src={createImageUrl(imageUrl)}
         alt={name}
         height="min-h-fit h-full"
         className="rounded-l-lg border-r object-cover"
       />
       <div className="col-span-2 flex flex-col gap-2 divide-y p-4 ">
         <div className="h-full overflow-hidden text-ellipsis sm:h-24 ">
-          <p className="truncate text-lg font-bold">{name}</p>
+          <div className="flex justify-between">
+            <p className="truncate text-lg font-bold">{name}</p>
+            {applied && <Badge color="secondary">내가 지원한 활동</Badge>}
+          </div>
           <p className="line-clamp-4 whitespace-pre-line text-sm text-gray-600 sm:line-clamp-3">
             {content}
           </p>
@@ -107,7 +114,9 @@ const GroupCard = ({
             </div>
           </div>
           <div className="flex flex-col justify-between text-sm md:pl-4">
-            <InfoRow label="팀장">{`${leaderName}(${leaderId})`}</InfoRow>
+            <InfoRow label="팀장">
+              {leaders ? `${leaderName}(${leaderId})` : '-'}
+            </InfoRow>
             <InfoRow label="정보">
               <div className="flex items-center text-sm text-gray-500">
                 <CertificateSolidOutline className="mr-1" />

--- a/apps/member/src/components/group/GroupCard/GroupCard.tsx
+++ b/apps/member/src/components/group/GroupCard/GroupCard.tsx
@@ -88,7 +88,7 @@ const GroupCard = ({
       <div className="col-span-2 flex flex-col gap-2 divide-y p-4 ">
         <div className="h-full overflow-hidden text-ellipsis sm:h-24 ">
           <p className="truncate text-lg font-bold">{name}</p>
-          <p className="line-clamp-4 text-sm text-gray-600 sm:line-clamp-3">
+          <p className="line-clamp-4 whitespace-pre-line text-sm text-gray-600 sm:line-clamp-3">
             {content}
           </p>
         </div>

--- a/apps/member/src/components/group/GroupCreateSection/GroupCreateSection.tsx
+++ b/apps/member/src/components/group/GroupCreateSection/GroupCreateSection.tsx
@@ -16,11 +16,11 @@ import { PATH } from '@constants/path';
 import { SELECT_ACTIVITY_GROUP_CATEGORY_TYPE } from '@constants/select';
 import {
   ACTIVITY_GROUP_CONTENT_MAX_LENGTH,
-  BOARD_CONTENT_MAX_LENGTH,
   BOARD_TITLE_MAX_LENGTH,
 } from '@constants/state';
 import useToast from '@hooks/common/useToast';
 import { useActivityGroupMutation } from '@hooks/queries';
+import { toKoreaActivityGroupCategory } from '@utils/string';
 
 import type { ActivityGroupCategoryType } from '@type/activity';
 
@@ -72,7 +72,7 @@ const ComponentWithLabel = ({
 
 const CategoryOptions = Object.entries(SELECT_ACTIVITY_GROUP_CATEGORY_TYPE).map(
   ([key, value]) => ({
-    name: key,
+    name: toKoreaActivityGroupCategory(key as ActivityGroupCategoryType),
     value,
   }),
 );
@@ -127,13 +127,13 @@ const GroupCreateSection = () => {
     } else if (content.length > ACTIVITY_GROUP_CONTENT_MAX_LENGTH) {
       return toast({
         state: 'error',
-        message: '내용은 200자 이내로 작성해주세요.',
+        message: `내용은 ${ACTIVITY_GROUP_CONTENT_MAX_LENGTH}자 이내로 작성해주세요.`,
       });
     } else if (curriculum) {
-      if (curriculum.length > BOARD_CONTENT_MAX_LENGTH) {
+      if (curriculum.length > ACTIVITY_GROUP_CONTENT_MAX_LENGTH) {
         return toast({
           state: 'error',
-          message: '커리큘럼은 200자 이내로 작성해주세요.',
+          message: `커리큘럼은 ${ACTIVITY_GROUP_CONTENT_MAX_LENGTH}자 이내로 작성해주세요.`,
         });
       }
     }
@@ -268,11 +268,13 @@ const GroupCreateSection = () => {
           />
           <p
             className={cn('mt-2 text-right text-xs', {
-              ' text-red-500': content.length > BOARD_CONTENT_MAX_LENGTH,
+              ' text-red-500':
+                curriculum &&
+                curriculum.length > ACTIVITY_GROUP_CONTENT_MAX_LENGTH,
             })}
           >
-            <span>{content.length}</span>
-            <span>{'/' + BOARD_CONTENT_MAX_LENGTH + '자'}</span>
+            <span>{curriculum ? curriculum.length : '0'}</span>
+            <span>{'/' + ACTIVITY_GROUP_CONTENT_MAX_LENGTH + '자'}</span>
           </p>
         </ComponentWithLabel>
         <Grid gap="md" col="2">

--- a/apps/member/src/components/group/WeeklyActivityCard/WeeklyActivityCard.tsx
+++ b/apps/member/src/components/group/WeeklyActivityCard/WeeklyActivityCard.tsx
@@ -3,9 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { RegularFileAltOutline } from '@clab-platforms/icon';
 
 import File from '@components/common/File/File';
+import Image from '@components/common/Image/Image';
 
 import { PATH_FINDER } from '@constants/path';
 import useToast from '@hooks/common/useToast';
+import { isImageFile } from '@utils/api';
 
 import { ActivityBoardType } from '@type/activity';
 import type { ResponseFile } from '@type/api';
@@ -44,7 +46,6 @@ const WeeklyActivityCard = ({
       });
     }
   };
-
   return (
     <div key={index + 1}>
       <div className="flex items-center justify-between pt-2">
@@ -54,13 +55,29 @@ const WeeklyActivityCard = ({
         </div>
       </div>
       <div className="overflow-hidden transition duration-500 ease-in-out">
-        <div className="mt-2 space-y-4">
+        <div className="mt-2 space-y-3">
           <p className="whitespace-pre-line break-keep text-sm">{content}</p>
-          {files?.map((file) => (
-            <File key={file.fileUrl} href={file.fileUrl}>
-              <p className="mt-4 text-gray-700 ">{file.originalFileName}</p>
-            </File>
-          ))}
+          <hr />
+          <div>
+            {files?.map((file) => (
+              <div key={file.fileUrl} className="flex gap-2">
+                {isImageFile(file.fileUrl) ? (
+                  <Image
+                    src={file.fileUrl}
+                    alt={file.originalFileName}
+                    height="w-[300px]"
+                    className="object-cover"
+                  />
+                ) : (
+                  <File
+                    href={file.fileUrl}
+                    name={file.originalFileName}
+                    key={file.fileUrl}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
           {assignments?.map(({ id: assignmentId, title: assignmentTitle }) => (
             <div
               key={assignmentId}

--- a/apps/member/src/components/modal/ActivityInfoModal/ActivityInfoModal.tsx
+++ b/apps/member/src/components/modal/ActivityInfoModal/ActivityInfoModal.tsx
@@ -8,6 +8,19 @@ import { createImageUrl } from '@utils/api';
 interface MemberInfoModalProps {
   id: number;
 }
+interface LongTextItemProps {
+  label: string;
+  text?: string;
+}
+
+const LongTextItem = ({ label, text }: LongTextItemProps) => {
+  return (
+    <li className="flex justify-between gap-4">
+      <span>{label}</span>
+      <span className="text-right font-semibold">{text || '-'}</span>
+    </li>
+  );
+};
 
 const ActivityInfoModal = ({ id }: MemberInfoModalProps) => {
   const { data, isLoading } = useActivityGroup(+id);
@@ -18,17 +31,22 @@ const ActivityInfoModal = ({ id }: MemberInfoModalProps) => {
     data;
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 overflow-auto ">
       <div className="scrollbar-hide max-h-[480px] overflow-auto rounded-lg border">
-        <Image src={createImageUrl(imageUrl)} alt={name} />
+        <Image
+          src={createImageUrl(imageUrl)}
+          alt={name}
+          height="max-h-[30vh]"
+          className="object-cover"
+        />
       </div>
-      <DetailsList>
+      <DetailsList className="h-full max-h-[50vh] overflow-scroll">
         <DetailsList.Item label="분류">{category}</DetailsList.Item>
         <DetailsList.Item label="이름">{name}</DetailsList.Item>
         <DetailsList.Item label="대상">{subject}</DetailsList.Item>
-        <DetailsList.Item label="설명">{content}</DetailsList.Item>
-        <DetailsList.Item label="커리큘럼">{curriculum}</DetailsList.Item>
-        <DetailsList.Item label="기술스텍">{techStack}</DetailsList.Item>
+        <LongTextItem label="설명" text={content} />
+        <LongTextItem label="커리큘럼" text={curriculum} />
+        <DetailsList.Item label="기술스텍">{techStack || '-'}</DetailsList.Item>
       </DetailsList>
     </div>
   );

--- a/apps/member/src/constants/state.ts
+++ b/apps/member/src/constants/state.ts
@@ -58,9 +58,9 @@ export const BOARD_TITLE_MAX_LENGTH = 100;
 export const BOARD_CONTENT_MAX_LENGTH = 5000;
 /**
  * 활동 내용의 최대 길이
- * 200자
+ * 1000자
  */
-export const ACTIVITY_GROUP_CONTENT_MAX_LENGTH = 200;
+export const ACTIVITY_GROUP_CONTENT_MAX_LENGTH = 1000;
 /**
  * 활동 그룹 멤버 역할을 정의합니다.
  */

--- a/apps/member/src/hooks/queries/activity/useActivityGroupBoardMutation.ts
+++ b/apps/member/src/hooks/queries/activity/useActivityGroupBoardMutation.ts
@@ -31,6 +31,7 @@ export function useActivityGroupBoardMutation() {
         ACTIVITY_QUERY_KEY.BOARD({ id: data.id }),
         ACTIVITY_QUERY_KEY.BOARD({ id: data.parentId, parent: true }),
         ACTIVITY_QUERY_KEY.DETAIL(data.groupId),
+        ACTIVITY_QUERY_KEY.MY_ASSIGNMENT(data.parentId),
       ];
 
       queryKeys.forEach((queryKey) => {
@@ -69,6 +70,7 @@ export function useActivityGroupBoardPatchMutation() {
         ACTIVITY_QUERY_KEY.BOARD({ id: data.id }),
         ACTIVITY_QUERY_KEY.BOARD({ id: data.parentId, parent: true }),
         ACTIVITY_QUERY_KEY.DETAIL(data.groupId),
+        ACTIVITY_QUERY_KEY.MY_ASSIGNMENT(data.parentId),
       ];
 
       queryKeys.forEach((queryKey) => {

--- a/apps/member/src/hooks/queries/activity/useActivityGroupDeleteMutation.ts
+++ b/apps/member/src/hooks/queries/activity/useActivityGroupDeleteMutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { deleteActivityGroup } from '@api/activity';
 import { ACTIVITY_QUERY_KEY } from '@constants/key';
+import { ACTIVITY_STATE } from '@constants/state';
 import useToast from '@hooks/common/useToast';
 
 /**
@@ -25,9 +26,15 @@ export function useActivityGroupDeleteMutation() {
           message: '활동 그룹 삭제에 성공했습니다.',
         });
       }
+      const queryKeys = [
+        ACTIVITY_QUERY_KEY.STATUS(ACTIVITY_STATE.END),
+        ACTIVITY_QUERY_KEY.STATUS(ACTIVITY_STATE.PROGRESSING),
+        ACTIVITY_QUERY_KEY.STATUS(ACTIVITY_STATE.WAITING),
+        ACTIVITY_QUERY_KEY.DETAIL(data),
+      ];
 
-      queryClient.invalidateQueries({
-        queryKey: ACTIVITY_QUERY_KEY.DETAIL(data),
+      queryKeys.forEach((queryKey) => {
+        queryClient.invalidateQueries({ queryKey });
       });
     },
   });

--- a/apps/member/src/hooks/queries/activity/useActivityGroupMemberMutation.ts
+++ b/apps/member/src/hooks/queries/activity/useActivityGroupMemberMutation.ts
@@ -33,6 +33,9 @@ export function useActivityGroupMemberMutation() {
       queryClient.invalidateQueries({
         queryKey: ACTIVITY_QUERY_KEY.APPLICATION(data),
       });
+      queryClient.invalidateQueries({
+        queryKey: ACTIVITY_QUERY_KEY.MY_APPLIED(),
+      });
     },
   });
 

--- a/apps/member/src/pages/GroupApplyPage/GroupApplyPage.tsx
+++ b/apps/member/src/pages/GroupApplyPage/GroupApplyPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@clab-platforms/design-system';
@@ -17,6 +17,7 @@ import {
   useActivityGroupMember,
   useActivityGroupMemberMutation,
 } from '@hooks/queries';
+import { toKoreaActivityGroupCategory } from '@utils/string';
 
 const GroupApplyPage = () => {
   const navigate = useNavigate();
@@ -25,11 +26,10 @@ const GroupApplyPage = () => {
     useActivityGroupMemberMutation();
   const toast = useToast();
 
-  const [groupID, setGroupID] = useState(0);
+  const [groupID, setGroupID] = useState<number | string>('none');
   const [reason, setReason] = useState('');
-
   const options = groupData.items.map((item) => ({
-    name: item.name,
+    name: `${toKoreaActivityGroupCategory(item.category)} / ${item.name} / ${item.leaders[0].name}`,
     value: item.id,
   }));
 
@@ -42,7 +42,7 @@ const GroupApplyPage = () => {
   };
 
   const handleApplyButtonClick = () => {
-    if (groupID === 0 || reason.length === 0) {
+    if (typeof groupID !== 'number' || reason.length === 0) {
       return toast({
         state: 'error',
         message: '필수 입력 사항을 모두 입력해주세요.',
@@ -51,7 +51,7 @@ const GroupApplyPage = () => {
 
     activityGroupMemberMutate(
       {
-        activityGroupId: groupID,
+        activityGroupId: +groupID,
         body: {
           applyReason: reason,
         },
@@ -60,18 +60,13 @@ const GroupApplyPage = () => {
     );
   };
 
-  useEffect(() => {
-    if (groupData.items.length && groupData.items[0].id)
-      setGroupID(groupData.items[0].id);
-  }, [groupData.items]);
-
   return (
     <Content>
       <Header title={['활동', '활동 신청']} path={PATH.ACTIVITY} />
       <Section className="space-y-4">
         <div>
           <Label htmlFor="select" required>
-            이름
+            활동
           </Label>
           <Select
             id="select"

--- a/apps/member/src/pages/GroupAssignmentPage/GroupAssignmentPage.tsx
+++ b/apps/member/src/pages/GroupAssignmentPage/GroupAssignmentPage.tsx
@@ -1,23 +1,31 @@
 import { useLocation, useParams } from 'react-router-dom';
 
+import { Badge, Button } from '@clab-platforms/design-system';
+
 import Content from '@components/common/Content/Content';
 import File from '@components/common/File/File';
 import Header from '@components/common/Header/Header';
+import Image from '@components/common/Image/Image';
 import Section from '@components/common/Section/Section';
+import ActivityBoardEditModal from '@components/group/ActivityBoardEditModal/ActivityBoardEditModal';
 import AssignmentListSection from '@components/group/AssignmentListSection/AssignmentListSection';
 import AssignmentUploadSection from '@components/group/AssignmentUploadSection/AssignmentUploadSection';
 
 import { GROUP_MESSAGE } from '@constants/message';
 import { PATH_FINDER } from '@constants/path';
 import { ACTIVITY_MEMBER_ROLE } from '@constants/state';
+import useModal from '@hooks/common/useModal';
 import {
   useActivityGroup,
   useActivityGroupBoardMyAssignment,
   useMyProfile,
 } from '@hooks/queries';
 import { useActivityGroupBoard } from '@hooks/queries/activity/useActivityGroupBoard';
+import { isImageFile } from '@utils/api';
+import { formattedDate } from '@utils/date';
 
 const GroupAssignmentPage = () => {
+  const { openModal } = useModal();
   const { id, assignmentId } = useParams();
   const { state } = useLocation();
   const { data: myProfile } = useMyProfile();
@@ -37,24 +45,51 @@ const GroupAssignmentPage = () => {
   );
   const feedback = myAssignment?.[0];
 
+  const handleEditNoticeClick = () => {
+    return openModal({
+      title: '수정하기',
+      custom: <ActivityBoardEditModal groupId={+id} prevData={board} />,
+    });
+  };
+
   return (
     <Content>
       <Header title={[...state.name]} path={PATH_FINDER.ACTIVITY_DETAIL(id)} />
       <Section>
-        <Section.Header title="과제 설명" />
+        <Section.Header title="과제 설명">
+          {isLeader && (
+            <Button size="sm" color="orange" onClick={handleEditNoticeClick}>
+              수정
+            </Button>
+          )}
+        </Section.Header>
         <Section.Body>
-          {board?.files.length !== 0 && (
-            <div className="mb-2 flex gap-2 text-sm">
-              <p className="hidden text-gray-500 sm:block">첨부파일 | </p>
-              {board.files.map((file) => (
-                <File key={file.fileUrl} href={file.fileUrl}>
-                  {file.originalFileName}
-                </File>
-              ))}
+          <Badge color="blue" className="px-1">
+            종료 일시 | {formattedDate(board?.dueDateTime)}
+          </Badge>
+          {board?.files && (
+            <div className="my-2 flex gap-2">
+              {board.files.map((file) =>
+                isImageFile(file.fileUrl) ? (
+                  <Image
+                    src={file.fileUrl}
+                    alt={file.originalFileName}
+                    height="w-[300px]"
+                    className="object-cover"
+                    key={file.fileUrl}
+                  />
+                ) : (
+                  <File
+                    href={file.fileUrl}
+                    name={file.originalFileName}
+                    key={file.fileUrl}
+                  />
+                ),
+              )}
             </div>
           )}
           <hr />
-          <p className="pt-3">{board?.content}</p>
+          <p className="py-3">{board?.content}</p>
         </Section.Body>
       </Section>
       {isLeader ? (

--- a/apps/member/src/pages/GroupPage/GroupPage.tsx
+++ b/apps/member/src/pages/GroupPage/GroupPage.tsx
@@ -23,7 +23,6 @@ import type { ActivityGroupItem } from '@type/activity';
 const MenubarItems = [
   { name: '현재 진행중인 그룹', value: ACTIVITY_STATE.PROGRESSING },
   { name: '나의 활동', value: ACTIVITY_MEMBER_STATE.ACCEPTED },
-  { name: '나의 지원', value: ACTIVITY_MEMBER_STATE.WAITING },
 ];
 const SubMenubarItems = [
   { name: '진행중', value: ACTIVITY_STATE.PROGRESSING },
@@ -45,21 +44,27 @@ const GroupPage = () => {
   );
 
   useEffect(() => {
+    const waitingActivityId = new Set(waitingData.items.map((item) => item.id));
+    const updatedProgressingData = progressingData.items.map((item) => ({
+      ...item,
+      applied: waitingActivityId.has(item.id) ? true : false,
+    }));
+
     switch (menu.value) {
       case ACTIVITY_STATE.PROGRESSING:
-        setRenderData(progressingData.items);
+        setRenderData(updatedProgressingData);
         break;
       case ACTIVITY_MEMBER_STATE.ACCEPTED:
         setRenderData(acceptedData.items);
         break;
-      case ACTIVITY_MEMBER_STATE.WAITING:
-        setRenderData(waitingData.items);
-        break;
     }
   }, [menu, progressingData, acceptedData, waitingData]);
+
   useEffect(() => {
     acceptedDataRefetch();
   }, [subMenu, acceptedDataRefetch]);
+
+  const reversedRenderData = [...renderData];
 
   return (
     <Content>
@@ -116,8 +121,8 @@ const GroupPage = () => {
               </Menubar>
             )}
           </>
-          {renderData.length > 0 ? (
-            renderData.map(({ id, ...rest }) => (
+          {reversedRenderData.length > 0 ? (
+            reversedRenderData.map(({ id, ...rest }) => (
               <GroupCard key={id} id={id} {...rest} />
             ))
           ) : (

--- a/apps/member/src/types/activity.ts
+++ b/apps/member/src/types/activity.ts
@@ -8,7 +8,7 @@ import {
 
 import type { ResponseFile } from './api';
 
-type MemberStatusType =
+export type MemberStatusType =
   (typeof ACTIVITY_MEMBER_STATE)[keyof typeof ACTIVITY_MEMBER_STATE];
 export type ActivityGroupBoardCategoryType =
   (typeof ACTIVITY_BOARD_CATEGORY_STATE)[keyof typeof ACTIVITY_BOARD_CATEGORY_STATE];

--- a/apps/member/src/utils/api.ts
+++ b/apps/member/src/utils/api.ts
@@ -86,3 +86,11 @@ export function authorization(token: string | null): Record<string, string> {
 export function isBase64(url: string): boolean {
   return /;base64,/.test(url);
 }
+/**
+ * 주어진 파일이 이미지인지 확인합니다.
+ * @param {string} fileUrl - 확인할 파일입니다.
+ * @returns {boolean} - 파일이 이미지라면 true, 아니면 false를 반환합니다.
+ */
+export const isImageFile = (fileUrl: string): boolean => {
+  return /\.(jpg|jpeg|png|gif)$/i.test(fileUrl);
+};

--- a/apps/member/src/utils/date.ts
+++ b/apps/member/src/utils/date.ts
@@ -30,7 +30,9 @@ export function toYYMMDD(date: string) {
  * @return {number} 오늘부터 주어진 날짜까지의 일수 차이, 절대값으로 반환됩니다.
  */
 export function calculateDDay(date: string): number {
-  return Math.abs(dayjs(date).diff(dayjs(), 'day'));
+  return Math.abs(
+    dayjs(date).startOf('day').diff(dayjs().startOf('day'), 'day'),
+  );
 }
 /**
  * 주어진 날짜를 'YY.MM.DD(dd) HH:mm' 형식으로 포맷합니다.

--- a/apps/member/src/utils/string.ts
+++ b/apps/member/src/utils/string.ts
@@ -1,6 +1,12 @@
 import { SERVICE_NAME } from '@constants/environment';
+import { SELECT_ACTIVITY_GROUP_CATEGORY_TYPE } from '@constants/select';
+import { ACTIVITY_MEMBER_ROLE, ACTIVITY_MEMBER_STATE } from '@constants/state';
 
-import { ActivityMemberRoleType } from '@type/activity';
+import {
+  ActivityGroupCategoryType,
+  ActivityMemberRoleType,
+  MemberStatusType,
+} from '@type/activity';
 import type { Bookstore, BookstoreKorean } from '@type/book';
 import type { CareerLevel, EmploymentType } from '@type/community';
 import { RoleLevelKey, RoleLevelType } from '@type/member';
@@ -160,10 +166,38 @@ export function toKoreaActivityGroupMemberLevel(
   memberLevel: ActivityMemberRoleType | null,
 ) {
   switch (memberLevel) {
-    case 'MEMBER':
+    case ACTIVITY_MEMBER_ROLE.MEMBER:
       return '멤버';
-    case 'LEADER':
+    case ACTIVITY_MEMBER_ROLE.LEADER:
       return '리더';
+    default:
+      return '-';
+  }
+}
+
+export function toKoreaActivityGroupCategory(
+  activityGroupCategory: ActivityGroupCategoryType | null,
+) {
+  switch (activityGroupCategory) {
+    case SELECT_ACTIVITY_GROUP_CATEGORY_TYPE.STUDY:
+      return '스터디';
+    case SELECT_ACTIVITY_GROUP_CATEGORY_TYPE.PROJECT:
+      return '프로젝트';
+    default:
+      return '-';
+  }
+}
+
+export function toKoreaActivityGroupMemberStatus(
+  status: MemberStatusType,
+): string {
+  switch (status) {
+    case ACTIVITY_MEMBER_STATE.ACCEPTED:
+      return '승인';
+    case ACTIVITY_MEMBER_STATE.REJECTED:
+      return '거절';
+    case ACTIVITY_MEMBER_STATE.WAITING:
+      return '대기';
     default:
       return '-';
   }


### PR DESCRIPTION
## Summary

> #229

운영진 대상으로 진행된 2차 활동 QA를 바탕으로 코드를 개선합니다.

## Tasks

- 캘린더 D-day 계산 표시 문제 수정
- 활동 내용 줄바꿈 문자 처리
- 스터디 정보 여백 크기 수정
- 공지사항 제목 조회 추가
- 활동 지원 `option`에 category, leader, name 표시, 선택하지 않은 경우는 미선택 `option` 설정
- 활동 생성 글자수 제한 (1000자) 설정, 카테고리 명 한글로 변환
- 현재 진행 중인 그룹 카드에서 내가 지원한 활동 `badge` 추가, 나의 지원 탭 삭제
- 다중 파일 첨부 및 파일 다운로드 기능 추가
- 그룹 정보 수정 내 board 추가 버튼 이동
- 활동 정보 조회 `modal` 크기 조정
- 과제 설명에 종료 일자 추가, 리더인 경우엔 수정 기능 추가

## ETC

피드백 사항이 많아서 1차 PR 먼저 올립니다. 남은 사항은 서버 수정사항 확인 후 작업하여 추가 PR 하도록 하겠습니다. 
이슈도 `notion`에 작성된 내용 확인 후 업데이트 하도록 하겠습니다.

## Screenshot

<img width="1552" alt="스크린샷 2024-09-08 오전 1 58 50" src="https://github.com/user-attachments/assets/eb2eae90-38e3-44d5-98b6-b0727a0fcfac">
<img width="1552" alt="스크린샷 2024-09-08 오전 1 59 02" src="https://github.com/user-attachments/assets/ea9426aa-ee85-4ba4-b352-e811b65e11eb">
<img width="1552" alt="스크린샷 2024-09-08 오전 2 00 02" src="https://github.com/user-attachments/assets/b367c7b2-f73b-436a-b700-4655e90ee7d2">
<img width="1552" alt="스크린샷 2024-09-08 오전 2 00 29" src="https://github.com/user-attachments/assets/870db51a-deba-4a68-ac60-2c96342a081e">
<img width="1552" alt="스크린샷 2024-09-08 오전 2 02 12" src="https://github.com/user-attachments/assets/cba998fe-64a5-4066-91e3-4d3b3223d548">
<img width="1552" alt="스크린샷 2024-09-08 오전 2 03 01" src="https://github.com/user-attachments/assets/8eab973b-1975-4cdd-af94-c6337ea04154">
<img width="1552" alt="스크린샷 2024-09-08 오전 2 03 53" src="https://github.com/user-attachments/assets/821c44b8-4191-4be9-9bd3-963b60aa2863">