### PR TITLE
feat(design-system): Input 컴포넌트 `required` 설정 시 시각적 표시 추가

### DIFF
--- a/packages/design-system/src/Input/Input.tsx
+++ b/packages/design-system/src/Input/Input.tsx
@@ -8,6 +8,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   labelClassName?: string;
   inputClassName?: string;
   messageClassName?: string;
+  required?: boolean;
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -20,6 +21,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       labelClassName,
       inputClassName,
       messageClassName,
+      required,
       ...rest
     },
     ref,
@@ -32,6 +34,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             className={cn('mb-1 ml-1 text-xs', labelClassName)}
           >
             {label}
+            {required && <span className="font-bol ml-1 text-red-400">*</span>}
           </label>
         )}
         <input
@@ -41,6 +44,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             'outline-clab-primary rounded-lg border p-2',
             inputClassName,
           )}
+          required={required}
           {...rest}
         />
         {message && (

--- a/packages/design-system/src/Input/Input.tsx
+++ b/packages/design-system/src/Input/Input.tsx
@@ -34,7 +34,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             className={cn('mb-1 ml-1 text-xs', labelClassName)}
           >
             {label}
-            {required && <span className="font-bol ml-1 text-red-400">*</span>}
+            {required && (
+              <span className="font-bol ml-0.5 text-red-400">*</span>
+            )}
           </label>
         )}
         <input


### PR DESCRIPTION
## Summary

> #230 

`Input` 컴포넌트에 `required` 설정 시 시각적으로 해당 항목을 표시합니다.

## Tasks

- `labedl`이 존재하는 `Input` 컴포넌트에 `required` 설정 시 별표 표시를 추가했습니다.

## Screenshot

<img width="806" alt="image" src="https://github.com/user-attachments/assets/2b5200a4-5b1d-4a7d-9eeb-0633f664d920">