### PR TITLE
feat(member): 관리페이지 `Aside TOC Panel` 추가

### DIFF
--- a/.changeset/big-falcons-thank.md
+++ b/.changeset/big-falcons-thank.md
@@ -1,0 +1,5 @@
+---
+"@clab-platforms/member": patch
+---
+
+feat(member): 관리페이지 `Aside TOC Panel` 추가

--- a/apps/member/src/components/common/Section/Section.tsx
+++ b/apps/member/src/components/common/Section/Section.tsx
@@ -29,7 +29,9 @@ const Header = ({ children, title, description }: SectionHeaderProps) => {
   return (
     <div className="flex items-center justify-between">
       <div>
-        <h2 className="text-xl font-bold text-black">{title}</h2>
+        <h2 id={encodeURI(title)} className="text-xl font-bold text-black">
+          {title}
+        </h2>
         <p className="text-sm font-semibold text-gray-500">{description}</p>
       </div>
       <div className="flex items-center">{children}</div>

--- a/apps/member/src/components/common/Section/Section.tsx
+++ b/apps/member/src/components/common/Section/Section.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren } from 'react';
+import { type PropsWithChildren, useId } from 'react';
 
 import { cn } from '@clab-platforms/utils';
 
@@ -26,10 +26,12 @@ const Section = ({ className, children }: SectionProps) => {
 };
 
 const Header = ({ children, title, description }: SectionHeaderProps) => {
+  const id = useId();
+
   return (
     <div className="flex items-center justify-between">
       <div>
-        <h2 id={encodeURI(title)} className="text-xl font-bold text-black">
+        <h2 id={id} className="text-xl font-bold text-black">
           {title}
         </h2>
         <p className="text-sm font-semibold text-gray-500">{description}</p>

--- a/apps/member/src/components/panels/PanelAside/PanelAside.tsx
+++ b/apps/member/src/components/panels/PanelAside/PanelAside.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 
 import ProfilePanel from '@components/panels/ProfilePanel/ProfilePanel';
+import ShortcutPanel from '@components/panels/ShortcutPanel/ShortcutPanel.tsx';
 
 import ActivityPanel from '../ActivityPanel/ActivityPanel';
 import AlarmPanel from '../AlarmPanel/AlarmPanel';
@@ -20,6 +21,9 @@ const PanelAside = () => {
       </Suspense>
       <Suspense>
         <BookPanel />
+      </Suspense>
+      <Suspense>
+        <ShortcutPanel />
       </Suspense>
     </aside>
   );

--- a/apps/member/src/components/panels/PanelAside/PanelAside.tsx
+++ b/apps/member/src/components/panels/PanelAside/PanelAside.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 
 import ProfilePanel from '@components/panels/ProfilePanel/ProfilePanel';
-import ShortcutPanel from '@components/panels/ShortcutPanel/ShortcutPanel.tsx';
+import ShortcutPanel from '@components/panels/ShortcutPanel/ShortcutPanel';
 
 import ActivityPanel from '../ActivityPanel/ActivityPanel';
 import AlarmPanel from '../AlarmPanel/AlarmPanel';

--- a/apps/member/src/components/panels/PanelAside/PanelAside.tsx
+++ b/apps/member/src/components/panels/PanelAside/PanelAside.tsx
@@ -22,9 +22,7 @@ const PanelAside = () => {
       <Suspense>
         <BookPanel />
       </Suspense>
-      <Suspense>
-        <ShortcutPanel />
-      </Suspense>
+      <ShortcutPanel />
     </aside>
   );
 };

--- a/apps/member/src/components/panels/ShortcutPanel/ShortcutPanel.tsx
+++ b/apps/member/src/components/panels/ShortcutPanel/ShortcutPanel.tsx
@@ -4,13 +4,15 @@ import { ChevronRightOutline, SettingsColor } from '@clab-platforms/icon';
 
 import Panel from '@components/common/Panel/Panel';
 
+import { PATH } from '@constants/path';
+
 export default function ShortcutPanel() {
   const headers = Array.from(document.querySelectorAll('h2'));
   const location = useLocation();
 
   return (
     <>
-      {location.pathname === '/manage' && (
+      {location.pathname === PATH.MANAGE && (
         <Panel className="sticky top-20">
           <Panel.Header
             icon={<SettingsColor />}
@@ -20,9 +22,12 @@ export default function ShortcutPanel() {
           <Panel.Body>
             <ul className="list-disc space-y-2 text-gray-400">
               {headers.map((h2) => (
-                <li key={h2.id} className="group flex justify-between">
+                <li
+                  key={`shortcut-${h2.id}`}
+                  className="group flex justify-between"
+                >
                   <a
-                    href={`#${decodeURI(h2.innerText)}`}
+                    href={`#${h2.id}`}
                     className="transition-all group-hover:translate-x-2 group-hover:font-bold group-hover:text-black"
                   >
                     {h2.innerText}

--- a/apps/member/src/components/panels/ShortcutPanel/ShortcutPanel.tsx
+++ b/apps/member/src/components/panels/ShortcutPanel/ShortcutPanel.tsx
@@ -1,0 +1,43 @@
+import { useLocation } from 'react-router-dom';
+
+import { ChevronRightOutline, SettingsColor } from '@clab-platforms/icon';
+
+import Panel from '@components/common/Panel/Panel';
+
+export default function ShortcutPanel() {
+  const headers = Array.from(document.querySelectorAll('h2'));
+  const location = useLocation();
+
+  return (
+    <>
+      {location.pathname === '/manage' && (
+        <Panel className="sticky top-20">
+          <Panel.Header
+            icon={<SettingsColor />}
+            label="바로가기"
+            description="클릭 시 해당 메뉴로 이동합니다."
+          />
+          <Panel.Body>
+            <ul className="list-disc space-y-2 text-gray-400">
+              {headers.map((h2) => (
+                <li key={h2.id} className="group flex justify-between">
+                  <a
+                    href={`#${decodeURI(h2.innerText)}`}
+                    className="transition-all group-hover:translate-x-2 group-hover:font-bold group-hover:text-black"
+                  >
+                    {h2.innerText}
+                  </a>
+                  <ChevronRightOutline
+                    className="opacity-0 transition-all group-hover:text-black group-hover:opacity-100"
+                    width={12}
+                    height={12}
+                  />
+                </li>
+              ))}
+            </ul>
+          </Panel.Body>
+        </Panel>
+      )}
+    </>
+  );
+}

--- a/apps/member/src/globals.css
+++ b/apps/member/src/globals.css
@@ -26,6 +26,8 @@
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
   font-size: 14px;
+  scroll-padding-top: 96px;
+  scroll-behavior: smooth;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary

> #230

- 관리 페이지에 숏컷 패널을 생성했습니다.

## Tasks

- 전역적으로 `scroll padding`을 적용했습니다. 이는 현재 바로가기로 이동 시 `nav`의 세로 크기 만큼 영역이 가려지기 때문입니다.
- 전역적으로 `scroll-behavior`를 `smooth`로 적용했습니다.
- `Section.Header`의 `h2` 컴포넌트에 `id` 값을 부여했습니다. (바로가기 이동을 위함)
- 바로가기 패널을 구현했습니다. 이는 `/manage` 경로에서만 표시됩니다.

## ETC

- 숏컷 패널은 `Section.Header`의 `h2`를 감지하고 이를 반영합니다. 따라서 관리페이지에서 TOC에 항목을 추가하고싶으시다면 `Section.Header`를 사용하시면 됩니다.

## Screenshot

<img width="310" alt="image" src="https://github.com/user-attachments/assets/7f66c8dd-d896-4494-8ed6-8bcbff2669fe">
