### PR TITLE
feat(member): 생일자 조회 에러 수정, 도서 추가 및 삭제/검색 기능 구현

### DIFF
--- a/apps/member/package.json
+++ b/apps/member/package.json
@@ -26,6 +26,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
+    "react-hook-form": "^7.51.4",
     "react-router-dom": "^6.21.2",
     "recoil": "^0.7.7"
   },

--- a/apps/member/src/api/book.ts
+++ b/apps/member/src/api/book.ts
@@ -147,3 +147,12 @@ export async function postRegisterBook(body: Book) {
     body,
   });
 }
+
+/**
+ * 도서 삭베
+ */
+export async function deleteBook(id: number) {
+  return server.del<never, BaseResponse<number>>({
+    url: END_POINT.BOOK_DETAIL(id),
+  });
+}

--- a/apps/member/src/api/book.ts
+++ b/apps/member/src/api/book.ts
@@ -8,6 +8,7 @@ import type {
   WithPaginationParams,
 } from '@type/api';
 import type {
+  Book,
   BookItem,
   BookLoanRecordConditionType,
   BookLoanRecordOverDueResponse,
@@ -134,5 +135,15 @@ export async function getBookLoanRecordOverdue({
 export function patchBookLoanRecordApprove(id: number) {
   return server.patch<null, BaseResponse<number>>({
     url: createURL(END_POINT.BOOK_LOAN_RECORD_APPROVE, id),
+  });
+}
+
+/**
+ * 도서 등록
+ */
+export async function postRegisterBook(body: Book) {
+  return server.post<Book, BaseResponse<number>>({
+    url: END_POINT.BOOK,
+    body,
   });
 }

--- a/apps/member/src/api/book.ts
+++ b/apps/member/src/api/book.ts
@@ -28,12 +28,18 @@ export interface GetBookLoanRecordConditionsParams
   isReturned?: boolean;
 }
 
+export interface GetBooksParams {
+  page: number;
+  size: number;
+  title?: string;
+}
+
 /**
  * 도서 목록 조회
  */
-export async function getBooks(page: number, size: number) {
+export async function getBooks({ page, size, title }: GetBooksParams) {
   const { data } = await server.get<ResponsePagination<BookItem>>({
-    url: createPagination(END_POINT.BOOK, { page, size }),
+    url: createPagination(END_POINT.BOOK, { page, size, title }),
   });
 
   return data;

--- a/apps/member/src/constants/head.ts
+++ b/apps/member/src/constants/head.ts
@@ -28,6 +28,7 @@ export const TABLE_HEAD = {
     '연체일수',
     '기능',
   ] as const,
+  BOOK_LIST: ['카테고리', '도서명', '작가', '상태', '기능'] as const,
   CALENDAR_TABLE: ['날짜', '일정'] as const,
   APPLY_TABLE: [
     '번호',

--- a/apps/member/src/constants/key.ts
+++ b/apps/member/src/constants/key.ts
@@ -186,9 +186,10 @@ export const BOOK_QUERY_KEY = {
   ALL: ['Book'],
   PAGES: () => [...BOOK_QUERY_KEY.ALL, 'pages'],
   DETAILS: () => [...BOOK_QUERY_KEY.ALL, 'details'],
-  PAGE: (pagination: WithPaginationParams) => [
+  PAGE: (pagination: WithPaginationParams, title: string) => [
     ...BOOK_QUERY_KEY.PAGES(),
     pagination,
+    title,
   ],
   DETAIL: (id: number) => [...BOOK_QUERY_KEY.DETAILS(), id],
 } as const;

--- a/apps/member/src/pages/LibraryDetailPage/components/BookDetailSection.tsx
+++ b/apps/member/src/pages/LibraryDetailPage/components/BookDetailSection.tsx
@@ -73,7 +73,7 @@ export function DetailsSection({ paramsId }: Props) {
    */
   const handleTabsChange = (value: string) => {
     const bookStore = toBookstore(value as BookstoreKorean);
-    const url = bookReviewParser(reviewLinks);
+    const url = bookReviewParser(reviewLinks || []);
     const targetUrl = url[bookStore] ?? `${BOOK_STORE_URL[bookStore]}${title}`;
     window.open(targetUrl, '_blank');
   };

--- a/apps/member/src/pages/LibraryPage/components/BookExplorerSection.tsx
+++ b/apps/member/src/pages/LibraryPage/components/BookExplorerSection.tsx
@@ -19,11 +19,14 @@ import { useBooks } from '../hooks/useBooks';
 
 export default function BookExplorerSection() {
   const [keyword, setKeyword] = useState('');
+  const [title, setTitle] = useState('');
   const { page, size, handlePageChange } = usePagination({ defaultSize: 16 });
 
-  const { data } = useBooks({ page, size });
+  const { data } = useBooks({ page, size, title });
 
-  const handleSearchButtonClick = () => {};
+  const handleSearchButtonClick = () => {
+    setTitle(keyword);
+  };
 
   return (
     <Section>
@@ -34,7 +37,7 @@ export default function BookExplorerSection() {
       <Section.Body>
         <div className="mb-4 flex items-center space-x-2">
           <Input
-            placeholder="찾으시는 도서를 입력해주세요"
+            placeholder="찾으시는 도서명을 입력해주세요"
             id="keyword"
             name="keyword"
             value={keyword}

--- a/apps/member/src/pages/LibraryPage/components/BookExplorerSection.tsx
+++ b/apps/member/src/pages/LibraryPage/components/BookExplorerSection.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { Input } from '@clab-platforms/design-system';
+import { SearchOutline } from '@clab-platforms/icon';
 import { cn } from '@clab-platforms/utils';
 
 import Image from '@components/common/Image/Image';
@@ -15,9 +18,12 @@ import type { BookItem } from '@type/book';
 import { useBooks } from '../hooks/useBooks';
 
 export default function BookExplorerSection() {
+  const [keyword, setKeyword] = useState('');
   const { page, size, handlePageChange } = usePagination({ defaultSize: 16 });
 
   const { data } = useBooks({ page, size });
+
+  const handleSearchButtonClick = () => {};
 
   return (
     <Section>
@@ -26,6 +32,22 @@ export default function BookExplorerSection() {
         description="소장 도서를 둘러볼 수 있어요"
       />
       <Section.Body>
+        <div className="mb-4 flex items-center space-x-2">
+          <Input
+            placeholder="찾으시는 도서를 입력해주세요"
+            id="keyword"
+            name="keyword"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            className="w-full"
+          />
+          <SearchOutline
+            width={24}
+            height={24}
+            className="hover:cursor-pointer"
+            onClick={handleSearchButtonClick}
+          />
+        </div>
         <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
           {data.items.map(({ id, ...props }) => (
             <BookCard key={id} id={id} {...props} />

--- a/apps/member/src/pages/LibraryPage/hooks/useBooks.ts
+++ b/apps/member/src/pages/LibraryPage/hooks/useBooks.ts
@@ -5,14 +5,20 @@ import { BOOK_QUERY_KEY } from '@constants/key';
 
 import { WithPaginationParams } from '@type/api';
 
-export interface UseBooksOptions extends WithPaginationParams {}
+export interface UseBooksOptions extends WithPaginationParams {
+  title?: string;
+}
 
 /**
  * 도서 목록을 조회합니다.
  */
-export const useBooks = ({ page = 0, size = 20 }: UseBooksOptions) => {
+export const useBooks = ({
+  page = 0,
+  size = 20,
+  title = '',
+}: UseBooksOptions) => {
   return useSuspenseQuery({
-    queryFn: () => getBooks(page, size),
-    queryKey: BOOK_QUERY_KEY.PAGE({ page, size }),
+    queryFn: () => getBooks({ page, size, title }),
+    queryKey: BOOK_QUERY_KEY.PAGE({ page, size }, title),
   });
 };

--- a/apps/member/src/pages/MainPage/hooks/useBirthday.ts
+++ b/apps/member/src/pages/MainPage/hooks/useBirthday.ts
@@ -17,7 +17,7 @@ interface Params extends WithPaginationParams {
 export function useBirthday({
   month = now().get('M') + 1,
   page = 0,
-  size = 6,
+  size = 99,
 }: Params = {}) {
   return useSuspenseQuery({
     queryKey: BIRTHDAY_QUERY_KEY.MONTH(month),

--- a/apps/member/src/pages/ManagePage/components/LibrarySection.tsx
+++ b/apps/member/src/pages/ManagePage/components/LibrarySection.tsx
@@ -56,6 +56,7 @@ export function LibrarySection() {
 
   const [mode, setMode] = useState<Mode>('condition');
   const [keyword, setKeyword] = useState('');
+  const [title, setTitle] = useState('');
 
   const { bookLoanRecordApproveMutate } = useBookLoanRecordApproveMutation();
   const { bookRegisterMutate } = useBookRegisterMutation();
@@ -69,7 +70,7 @@ export function LibrarySection() {
     page,
     size,
   });
-  const { data: bookList } = useBooks({ page, size: 10 });
+  const { data: bookList } = useBooks({ page, size: 10, title });
   const { bookDeleteMutate } = useBookDeleteMutation();
 
   const handleMenubarItemClick = (mode: Mode) => {
@@ -122,7 +123,9 @@ export function LibrarySection() {
     bookDeleteMutate(id);
   };
 
-  const handleSearchButtonClick = () => {};
+  const handleSearchButtonClick = () => {
+    setTitle(keyword);
+  };
 
   const renderMode = {
     condition: (
@@ -269,7 +272,7 @@ export function LibrarySection() {
       <>
         <div className="mb-4 flex items-center space-x-2">
           <Input
-            placeholder="찾으시는 도서를 입력해주세요"
+            placeholder="찾으시는 도서명을 입력해주세요"
             id="keyword"
             name="keyword"
             value={keyword}

--- a/apps/member/src/pages/ManagePage/components/LibrarySection.tsx
+++ b/apps/member/src/pages/ManagePage/components/LibrarySection.tsx
@@ -7,6 +7,7 @@ import {
   Menubar,
   Table,
 } from '@clab-platforms/design-system';
+import { SearchOutline } from '@clab-platforms/icon';
 import { cn } from '@clab-platforms/utils';
 
 import ActionButton from '@components/common/ActionButton/ActionButton';
@@ -54,6 +55,7 @@ export function LibrarySection() {
   });
 
   const [mode, setMode] = useState<Mode>('condition');
+  const [keyword, setKeyword] = useState('');
 
   const { bookLoanRecordApproveMutate } = useBookLoanRecordApproveMutation();
   const { bookRegisterMutate } = useBookRegisterMutation();
@@ -72,6 +74,7 @@ export function LibrarySection() {
 
   const handleMenubarItemClick = (mode: Mode) => {
     setMode(mode);
+    handlePageChange(1);
   };
 
   const handleApproveButtonClick = (id: number) => {
@@ -118,6 +121,8 @@ export function LibrarySection() {
   const handleBookDeleteButtonClick = (id: number) => {
     bookDeleteMutate(id);
   };
+
+  const handleSearchButtonClick = () => {};
 
   const renderMode = {
     condition: (
@@ -261,33 +266,51 @@ export function LibrarySection() {
       </div>
     ),
     view: (
-      <Table head={TABLE_HEAD.BOOK_LIST}>
-        {bookList.items.map(({ id, category, title, author, borrowerId }) => (
-          <Table.Row key={id}>
-            <Table.Cell>{category}</Table.Cell>
-            <Table.Cell>{title}</Table.Cell>
-            <Table.Cell>{author}</Table.Cell>
-            <Table.Cell>
-              <span
-                className={cn(
-                  'text-xs',
-                  borrowerId ? 'text-pink-600' : 'text-green-600',
-                )}
-              >
-                {borrowerId ? BOOK_STATE.BORROWED : BOOK_STATE.AVAILABLE}
-              </span>
-            </Table.Cell>
-            <Table.Cell>
-              <ActionButton
-                color="red"
-                onClick={() => handleBookDeleteButtonClick(id)}
-              >
-                삭제
-              </ActionButton>
-            </Table.Cell>
-          </Table.Row>
-        ))}
-      </Table>
+      <>
+        <div className="mb-4 flex items-center space-x-2">
+          <Input
+            placeholder="찾으시는 도서를 입력해주세요"
+            id="keyword"
+            name="keyword"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            className="w-full"
+          />
+          <SearchOutline
+            width={24}
+            height={24}
+            className="hover:cursor-pointer"
+            onClick={handleSearchButtonClick}
+          />
+        </div>
+        <Table head={TABLE_HEAD.BOOK_LIST}>
+          {bookList.items.map(({ id, category, title, author, borrowerId }) => (
+            <Table.Row key={id}>
+              <Table.Cell>{category}</Table.Cell>
+              <Table.Cell>{title}</Table.Cell>
+              <Table.Cell>{author}</Table.Cell>
+              <Table.Cell>
+                <span
+                  className={cn(
+                    'text-xs',
+                    borrowerId ? 'text-pink-600' : 'text-green-600',
+                  )}
+                >
+                  {borrowerId ? BOOK_STATE.BORROWED : BOOK_STATE.AVAILABLE}
+                </span>
+              </Table.Cell>
+              <Table.Cell>
+                <ActionButton
+                  color="red"
+                  onClick={() => handleBookDeleteButtonClick(id)}
+                >
+                  삭제
+                </ActionButton>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table>
+      </>
     ),
   }[mode];
 

--- a/apps/member/src/pages/ManagePage/components/LibrarySection.tsx
+++ b/apps/member/src/pages/ManagePage/components/LibrarySection.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react';
 
-import { Menubar, Table } from '@clab-platforms/design-system';
+import {
+  Button,
+  Grid,
+  Input,
+  Menubar,
+  Table,
+} from '@clab-platforms/design-system';
 
 import ActionButton from '@components/common/ActionButton/ActionButton';
 import Pagination from '@components/common/Pagination/Pagination';
@@ -8,25 +14,45 @@ import { Section } from '@components/common/Section';
 import BookLoanConditionStatusBadge from '@components/library/BookLoanConditionStatusBadge';
 
 import { TABLE_HEAD } from '@constants/head';
+import { ERROR_MESSAGE } from '@constants/message';
 import { usePagination } from '@hooks/common/usePagination';
+import useToast from '@hooks/common/useToast';
 import { useBookLoanRecordConditions } from '@hooks/queries';
 import { calculateDDay, formattedDate } from '@utils/date';
 
+import type { Book } from '@type/book';
+
 import { useBookLoanRecordApproveMutation } from '../hooks/useBookLoanRecordApproveMutation';
 import { useBookLoanRecordOverdue } from '../hooks/useBookLoanRecordOverdue';
+import { useBookRegisterMutation } from '../hooks/useBookRegisterMutation';
 import { useMemberInfoModal } from '../hooks/useMemberInfoModal';
 
-type Mode = 'condition' | 'overdue';
+type Mode = 'condition' | 'overdue' | 'register';
 
 export function LibrarySection() {
+  const toast = useToast();
   const { open } = useMemberInfoModal();
   const { page, size, handlePageChange } = usePagination({
     sectionName: 'library',
+  });
+  const [inputs, setInputs] = useState<Book>({
+    category: '',
+    title: '',
+    author: '',
+    publisher: '',
+    imageUrl: '',
+    reviewLinks: [],
+  });
+  const [links, setLinks] = useState({
+    yes24Url: '',
+    kyoboUrl: '',
+    aladinUrl: '',
   });
 
   const [mode, setMode] = useState<Mode>('condition');
 
   const { bookLoanRecordApproveMutate } = useBookLoanRecordApproveMutation();
+  const { bookRegisterMutate } = useBookRegisterMutation();
   const { data: bookLoanRecordCondition } = useBookLoanRecordConditions({
     hasPermission: true,
     isReturned: false,
@@ -48,6 +74,39 @@ export function LibrarySection() {
 
   const handleMemberInfoClick = (memberId: string) => {
     open({ memberId: memberId });
+  };
+
+  const handleInputsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputs((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  const handleLinksChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLinks((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  const handleRegisterButtonClick = async () => {
+    const { category, title, author, publisher } = inputs;
+    if (!category || !title || !author || !publisher) {
+      return toast({
+        state: 'error',
+        message: ERROR_MESSAGE.NO_DATA,
+      });
+    }
+
+    const reviewLinkList = Object.values(links).filter((link) => link !== '');
+
+    setInputs((prev) => ({
+      ...prev,
+      reviewLinks: reviewLinkList,
+    }));
+
+    bookRegisterMutate(inputs);
   };
 
   const renderMode = {
@@ -111,13 +170,93 @@ export function LibrarySection() {
         )}
       </Table>
     ),
+    register: (
+      <div className="space-y-2">
+        <Grid gap="md" col="2">
+          <Input
+            label="카테고리"
+            id="category"
+            name="category"
+            placeholder="카테고리를 작성해주세요"
+            value={inputs.category}
+            onChange={handleInputsChange}
+          />
+          <Input
+            label="제목"
+            id="title"
+            name="title"
+            placeholder="제목을 작성해주세요"
+            value={inputs.title}
+            onChange={handleInputsChange}
+            required
+          />
+        </Grid>
+        <Grid gap="md" col="2">
+          <Input
+            label="저자"
+            id="author"
+            name="author"
+            placeholder="저자를 작성해주세요"
+            value={inputs.author}
+            onChange={handleInputsChange}
+          />
+          <Input
+            label="출판사"
+            id="publisher"
+            name="publisher"
+            placeholder="출판사를 작성해주세요"
+            value={inputs.publisher}
+            onChange={handleInputsChange}
+          />
+        </Grid>
+        <Input
+          label="이미지 URL"
+          id="imageUrl"
+          name="imageUrl"
+          placeholder="ex) https://image.yes24.com/goods/123161563/XL"
+          value={inputs.imageUrl}
+          onChange={handleInputsChange}
+        />
+        <Input
+          label="서점 링크 - yes24"
+          id="yes24Url"
+          name="yes24Url"
+          placeholder="ex) https://www.yes24.com/Product/Goods/7516911"
+          value={links.yes24Url}
+          onChange={handleLinksChange}
+        />
+        <Input
+          label="서점 링크 - 교보문고"
+          id="kyoboUrl"
+          name="kyoboUrl"
+          placeholder="ex) https://product.kyobobook.co.kr/detail/S000000935360"
+          value={links.kyoboUrl}
+          onChange={handleLinksChange}
+        />
+        <Input
+          label="서점 링크 - 알라딘"
+          id="aladinUrl"
+          name="aladinUrl"
+          placeholder="ex) https://www.aladin.co.kr/shop/wproduct.aspx?ISBN=8960773433&start=pnaver_02"
+          value={links.aladinUrl}
+          onChange={handleLinksChange}
+        />
+        <Button
+          color="blue"
+          className="w-full"
+          onClick={handleRegisterButtonClick}
+        >
+          등록하기
+        </Button>
+      </div>
+    ),
   }[mode];
 
   return (
     <Section>
       <Section.Header
         title="도서관"
-        description="대여자와 연체자를 확인할 수 있어요"
+        description="대여자와 연체자를 확인하거나 신규 도서를 등록할 수 있어요"
       >
         <Menubar>
           <Menubar.Item
@@ -132,21 +271,29 @@ export function LibrarySection() {
           >
             연체
           </Menubar.Item>
+          <Menubar.Item
+            selected={mode === 'register'}
+            onClick={() => handleMenubarItemClick('register')}
+          >
+            등록
+          </Menubar.Item>
         </Menubar>
       </Section.Header>
       <Section.Body>
         {renderMode}
-        <Pagination
-          className="mt-4 justify-center"
-          page={page}
-          postLimit={size}
-          totalItems={
-            mode === 'condition'
-              ? bookLoanRecordCondition.totalItems
-              : bookLoanRecordOverdue.totalItems
-          }
-          onChange={handlePageChange}
-        />
+        {mode !== 'register' && (
+          <Pagination
+            className="mt-4 justify-center"
+            page={page}
+            postLimit={size}
+            totalItems={
+              mode === 'condition'
+                ? bookLoanRecordCondition.totalItems
+                : bookLoanRecordOverdue.totalItems
+            }
+            onChange={handlePageChange}
+          />
+        )}
       </Section.Body>
     </Section>
   );

--- a/apps/member/src/pages/ManagePage/hooks/useBookDeleteMutation.ts
+++ b/apps/member/src/pages/ManagePage/hooks/useBookDeleteMutation.ts
@@ -30,5 +30,8 @@ export function useBookDeleteMutation() {
     },
   });
 
-  return { bookDeleteMutate: mutation.mutate };
+  return {
+    bookDeleteMutate: mutation.mutate,
+    bookDeleteIsPending: mutation.isPending,
+  };
 }

--- a/apps/member/src/pages/ManagePage/hooks/useBookDeleteMutation.ts
+++ b/apps/member/src/pages/ManagePage/hooks/useBookDeleteMutation.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteBook } from '@api/book';
+import { BOOK_QUERY_KEY } from '@constants/key';
+import useToast from '@hooks/common/useToast';
+
+/**
+ * 도서를 삭제합니다.
+ */
+export function useBookDeleteMutation() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const mutation = useMutation({
+    mutationFn: deleteBook,
+    onSuccess: (data) => {
+      if (!data) {
+        return toast({
+          state: 'error',
+          message: '도서 삭제에 실패했어요.',
+        });
+      } else {
+        queryClient.invalidateQueries({ queryKey: BOOK_QUERY_KEY.ALL });
+
+        toast({
+          state: 'success',
+          message: '도서가 삭제됐어요.',
+        });
+      }
+    },
+  });
+
+  return { bookDeleteMutate: mutation.mutate };
+}

--- a/apps/member/src/pages/ManagePage/hooks/useBookRegisterMutation.ts
+++ b/apps/member/src/pages/ManagePage/hooks/useBookRegisterMutation.ts
@@ -32,5 +32,8 @@ export function useBookRegisterMutation() {
     },
   });
 
-  return { bookRegisterMutate: mutation.mutate };
+  return {
+    bookRegisterMutate: mutation.mutate,
+    bookRegisterIsPending: mutation.isPending,
+  };
 }

--- a/apps/member/src/pages/ManagePage/hooks/useBookRegisterMutation.ts
+++ b/apps/member/src/pages/ManagePage/hooks/useBookRegisterMutation.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { postRegisterBook } from '@api/book';
+import { BOOK_QUERY_KEY } from '@constants/key';
+import useToast from '@hooks/common/useToast';
+
+/**
+ * 도서를 추가합니다.
+ */
+export function useBookRegisterMutation() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const mutation = useMutation({
+    mutationFn: postRegisterBook,
+    onSuccess: ({ success, errorMessage, data: id }) => {
+      if (success) {
+        queryClient.invalidateQueries({
+          queryKey: BOOK_QUERY_KEY.DETAIL(id),
+        });
+        queryClient.invalidateQueries({
+          queryKey: BOOK_QUERY_KEY.PAGES(),
+        });
+
+        toast({
+          state: 'success',
+          message: '도서를 추가했어요.',
+        });
+      } else if (errorMessage) {
+        toast({ state: 'error', message: '도서 등록에 실패했어요.' });
+      }
+    },
+  });
+
+  return { bookRegisterMutate: mutation.mutate };
+}

--- a/apps/member/src/types/book.ts
+++ b/apps/member/src/types/book.ts
@@ -7,16 +7,19 @@ export type BookConditionStatus =
   | 'REJECTED'
   | 'RETURNED';
 
-export interface BookItem {
-  id: number;
-  borrowerId: string | null;
-  borrowerName: string | null;
+export interface Book {
   category: string;
   title: string;
   author: string;
   publisher: string;
-  imageUrl: string;
-  reviewLinks: Array<string>;
+  imageUrl?: string;
+  reviewLinks?: Array<string>;
+}
+
+export interface BookItem extends Book {
+  id: number;
+  borrowerId: string | null;
+  borrowerName: string | null;
   dueDate: null;
   createdAt: string;
   updatedAt: string | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       react-dropzone:
         specifier: ^14.2.3
         version: 14.2.3(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.51.4
+        version: 7.51.4(react@18.2.0)
       react-router-dom:
         specifier: ^6.21.2
         version: 6.22.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)


### PR DESCRIPTION
## Summary

> #265 

- 생일자 조회 시 제한된 size로 생일자가 전부 나타나지 않던 문제를 해결했어요.
- 도서 등록과 삭제, 검색을 할 수 있도록 기능을 추가했어요.

## Tasks

- 생일자 조회 API size를 99로 변경
- 관리페이지의 도서 탭에서 도서 등록, 삭제를 위한 탭 추가
- 도서 페이지 내에서 검색 기능 추가

## Screenshot

<img width="912" alt="스크린샷 2025-02-05 오후 6 16 31" src="https://github.com/user-attachments/assets/97d996a6-42c6-49b9-9341-6ed2cc1c3629" />
<img width="915" alt="스크린샷 2025-02-05 오후 6 16 39" src="https://github.com/user-attachments/assets/a380156b-81b9-42f0-be2c-7f164194561c" />
<img width="922" alt="스크린샷 2025-02-05 오후 6 16 16" src="https://github.com/user-attachments/assets/a2a18155-b5fb-4bd4-95ec-45e282d1137f" />
