### PR TITLE
feat(member): 계정 삭제 버튼 추가

### DIFF
--- a/apps/auth/src/components/Login/LoginForm/LoginForm.tsx
+++ b/apps/auth/src/components/Login/LoginForm/LoginForm.tsx
@@ -65,7 +65,7 @@ const LoginForm = ({ data, onLogin, onTwoFactor }: LoginFormProps) => {
         {...register('password')}
         type="password"
         label="비밀번호"
-        placeholder="비빌번호를 입력해주세요."
+        placeholder="비밀번호를 입력해주세요."
         aria-invalid={errors.password ? 'true' : 'false'}
         message={errors.password?.message}
         inputClassName={errors.password && ' border-red-500'}

--- a/apps/member/src/api/member.ts
+++ b/apps/member/src/api/member.ts
@@ -160,3 +160,12 @@ export async function postResendMemberPassword(memberId: string) {
 
   return data;
 }
+
+/**
+ * 멤버 계정 삭제
+ */
+export function deleteMember(id: string) {
+  return server.del<never, BaseResponse<string>>({
+    url: END_POINT.MEMBER_DELETE(id),
+  });
+}

--- a/apps/member/src/components/manage/ManageLevelSection/RoleEditView.tsx
+++ b/apps/member/src/components/manage/ManageLevelSection/RoleEditView.tsx
@@ -15,6 +15,7 @@ import Pagination from '@components/common/Pagination/Pagination';
 import { TABLE_HEAD, TABLE_HEAD_ACTION } from '@constants/head';
 import { usePagination } from '@hooks/common/usePagination';
 import { useMemberRole } from '@hooks/queries/member';
+import { useMemberDeleteModal } from '@pages/ManagePage/hooks/useMemberDeleteModal';
 import { useMemberInfoModal } from '@pages/ManagePage/hooks/useMemberInfoModal';
 import { useMemberPasswordResendModal } from '@pages/ManagePage/hooks/useMemberPasswordResendModal';
 import { useMemberPermissionSettingModal } from '@pages/ManagePage/hooks/useMemberPermissionSettingModal';
@@ -55,6 +56,8 @@ const RoleEditView = ({ role }: RoleEditViewProps) => {
     useMemberPermissionSettingModal();
 
   const { open: passwordResendModalOpen } = useMemberPasswordResendModal();
+
+  const { open: memberDeleteModalOpen } = useMemberDeleteModal();
 
   const handleSearchClick = () => {
     refetch();
@@ -113,6 +116,13 @@ const RoleEditView = ({ role }: RoleEditViewProps) => {
                 onClick={() => passwordResendModalOpen({ memberId: id, name })}
               >
                 비밀번호 재전송
+              </ActionButton>
+              <ActionButton
+                type="button"
+                color="red"
+                onClick={() => memberDeleteModalOpen({ memberId: id, name })}
+              >
+                계정 삭제
               </ActionButton>
             </Table.Cell>
           </Table.Row>

--- a/apps/member/src/constants/api.ts
+++ b/apps/member/src/constants/api.ts
@@ -26,6 +26,7 @@ export const END_POINT = {
   MEMBER_ADD: `v1/members`,
   MEMBER_PASSWORD_RESEND: (memberId: string) =>
     `/v1/members/password/${memberId}/resend`,
+  MEMBER_DELETE: (memberId: string) => `/v1/members/${memberId}`,
   // -- 커뮤니티
   BOARDS: `/v1/boards`,
   BOARDS_LIST: `/v1/boards/category`,

--- a/apps/member/src/pages/ManagePage/hooks/useMemberDelete.ts
+++ b/apps/member/src/pages/ManagePage/hooks/useMemberDelete.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { deleteMember } from '@api/member';
+import { useToast } from '@hooks/common/useToast';
+
+/**
+ * 멤버의 계정을 삭제합니다.
+ */
+export function useMemberDelete() {
+  const { addToast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: deleteMember,
+    onSuccess: (data) => {
+      if (!data) {
+        return addToast({
+          state: 'error',
+          message: '계정 삭제에 실패했어요.',
+        });
+      } else {
+        addToast({
+          state: 'success',
+          message: '계정이 삭제됐어요.',
+        });
+      }
+    },
+  });
+
+  return {
+    memberDeleteMutate: mutation.mutate,
+  };
+}

--- a/apps/member/src/pages/ManagePage/hooks/useMemberDeleteModal.tsx
+++ b/apps/member/src/pages/ManagePage/hooks/useMemberDeleteModal.tsx
@@ -1,0 +1,57 @@
+import { useCallback, useMemo } from 'react';
+
+import { useModal } from '@hooks/common/useModal';
+
+import { useMemberDelete } from './useMemberDelete';
+
+interface Options {
+  memberId: string;
+  name: string;
+}
+
+/**
+ * 비밀번호 재전송 모달을 엽니다.
+ */
+export function useMemberDeleteModal() {
+  const { open } = useModal();
+  const { memberDeleteMutate } = useMemberDelete();
+
+  const handleMemberDeleteButtonClick = useCallback(
+    (memberId: string) => {
+      memberDeleteMutate(memberId);
+    },
+    [memberDeleteMutate],
+  );
+
+  return useMemo(
+    () => ({
+      open: (options: Options) =>
+        open({
+          title: '계정 삭제',
+          content: <MemberDeleteModal {...options} />,
+          accept: {
+            text: '삭제',
+            onClick: () => handleMemberDeleteButtonClick(options.memberId),
+          },
+        }),
+    }),
+    [open, handleMemberDeleteButtonClick],
+  );
+}
+
+interface Props extends Options {}
+
+function MemberDeleteModal({ memberId, name }: Props) {
+  return (
+    <div className="flex flex-col">
+      <div className="flex justify-between">
+        <p className="p-1.5 text-left text-sm">
+          <span className="font-bold text-red-400">
+            {memberId + ' ' + name}
+          </span>
+          의 계정을 삭제합니다.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/member/src/pages/MyPage/components/ProfileSection.tsx
+++ b/apps/member/src/pages/MyPage/components/ProfileSection.tsx
@@ -57,7 +57,7 @@ export function ProfileSection() {
         <div className="flex gap-2">
           {isEdit && (
             <Button size="sm" onClick={() => open({ memberId: data.id })}>
-              비빌번호 변경
+              비밀번호 변경
             </Button>
           )}
           <Button


### PR DESCRIPTION
## Summary

> #276 

관리페이지 내에 계정 삭제를 위한 버튼을 추가했어요.


## Tasks

- 계정 삭제 버튼 추가
- 오타 수정


## Screenshot
<img width="929" alt="스크린샷 2025-03-28 오후 9 00 46" src="https://github.com/user-attachments/assets/b15854c7-e607-4119-9835-25466f5403a7" />
<img width="562" alt="스크린샷 2025-03-28 오후 9 00 08" src="https://github.com/user-attachments/assets/15a0b181-444c-4e19-a3fb-50f858b72098" />